### PR TITLE
Registry package model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOLANG_VERSION=1.17
 FROM golang:${GOLANG_VERSION} AS builder
 
-LABEL VERSION="0.1.0"
+LABEL VERSION="0.1.1"
 LABEL org.opencontainers.image.description "Simple CD tool for docker swarm"
 RUN apt-get -qq update && apt-get -yqq install upx
 

--- a/lib/github/data.go
+++ b/lib/github/data.go
@@ -3,8 +3,8 @@ package github
 import "time"
 
 type GithubPackageWebhook struct {
-	Action  string `json:"action"`
-	Package struct {
+	Action          string `json:"action"`
+	RegistryPackage struct {
 		ID          int       `json:"id"`
 		Name        string    `json:"name"`
 		Namespace   string    `json:"namespace"`
@@ -35,11 +35,72 @@ type GithubPackageWebhook struct {
 			SiteAdmin         bool   `json:"site_admin"`
 		} `json:"owner"`
 		PackageVersion struct {
-			ID                int           `json:"id"`
-			Version           string        `json:"version"`
-			Name              string        `json:"name"`
-			Description       string        `json:"description"`
-			Summary           string        `json:"summary"`
+			ID          int    `json:"id"`
+			Version     string `json:"version"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Summary     string `json:"summary"`
+			Body        struct {
+				Repository struct {
+					Repository struct {
+						ID                    int         `json:"id"`
+						Name                  string      `json:"name"`
+						OwnerID               int         `json:"owner_id"`
+						ParentID              interface{} `json:"parent_id"`
+						Sandbox               interface{} `json:"sandbox"`
+						UpdatedAt             time.Time   `json:"updated_at"`
+						CreatedAt             time.Time   `json:"created_at"`
+						Public                bool        `json:"public"`
+						Description           string      `json:"description"`
+						Homepage              interface{} `json:"homepage"`
+						SourceID              int         `json:"source_id"`
+						PublicPush            interface{} `json:"public_push"`
+						DiskUsage             int         `json:"disk_usage"`
+						Locked                bool        `json:"locked"`
+						PushedAt              time.Time   `json:"pushed_at"`
+						WatcherCount          int         `json:"watcher_count"`
+						PublicForkCount       int         `json:"public_fork_count"`
+						PrimaryLanguageNameID int         `json:"primary_language_name_id"`
+						HasIssues             bool        `json:"has_issues"`
+						HasWiki               bool        `json:"has_wiki"`
+						HasDownloads          bool        `json:"has_downloads"`
+						RawData               struct {
+							Data struct {
+								CreatedByUserID          int           `json:"created_by_user_id"`
+								PrimaryLanguageName      string        `json:"primary_language_name"`
+								CompletedOnboardingTasks []interface{} `json:"completed_onboarding_tasks"`
+							} `json:"data"`
+						} `json:"raw_data"`
+						OrganizationID    interface{} `json:"organization_id"`
+						DisabledAt        interface{} `json:"disabled_at"`
+						DisabledBy        interface{} `json:"disabled_by"`
+						DisablingReason   interface{} `json:"disabling_reason"`
+						HealthStatus      interface{} `json:"health_status"`
+						PushedAtUsec      int         `json:"pushed_at_usec"`
+						Active            bool        `json:"active"`
+						ReflogSyncEnabled bool        `json:"reflog_sync_enabled"`
+						MadePublicAt      time.Time   `json:"made_public_at"`
+						UserHidden        int         `json:"user_hidden"`
+						Maintained        bool        `json:"maintained"`
+						Template          bool        `json:"template"`
+						OwnerLogin        string      `json:"owner_login"`
+						WorldWritableWiki bool        `json:"world_writable_wiki"`
+						RefsetUpdatedAt   time.Time   `json:"refset_updated_at"`
+						PropertiesVersion int         `json:"properties_version"`
+						DisablingDetail   interface{} `json:"disabling_detail"`
+					} `json:"repository"`
+				} `json:"repository"`
+				Info struct {
+					Type       string      `json:"type"`
+					Oid        string      `json:"oid"`
+					Mode       int         `json:"mode"`
+					Name       string      `json:"name"`
+					Path       string      `json:"path"`
+					Size       interface{} `json:"size"`
+					Collection bool        `json:"collection"`
+				} `json:"info"`
+				Formatted bool `json:"_formatted"`
+			} `json:"body"`
 			HTMLURL           string        `json:"html_url"`
 			TargetCommitish   string        `json:"target_commitish"`
 			TargetOid         string        `json:"target_oid"`
@@ -85,7 +146,7 @@ type GithubPackageWebhook struct {
 			URL      string `json:"url"`
 			Vendor   string `json:"vendor"`
 		} `json:"registry"`
-	} `json:"package"`
+	} `json:"registry_package"`
 	Repository struct {
 		ID       int    `json:"id"`
 		NodeID   string `json:"node_id"`
@@ -113,7 +174,7 @@ type GithubPackageWebhook struct {
 			SiteAdmin         bool   `json:"site_admin"`
 		} `json:"owner"`
 		HTMLURL          string        `json:"html_url"`
-		Description      interface{}   `json:"description"`
+		Description      string        `json:"description",omitempty`
 		Fork             bool          `json:"fork"`
 		URL              string        `json:"url"`
 		ForksURL         string        `json:"forks_url"`

--- a/main.go
+++ b/main.go
@@ -42,11 +42,11 @@ func setupRouter() *gin.Engine {
 				return
 			}
 
-			image, tag, err := containers.ParseImageName(package_update.Package.PackageVersion.PackageURL)
+			image, tag, err := containers.ParseImageName(package_update.RegistryPackage.PackageVersion.PackageURL)
 
 			if err != nil {
-				log.WithFields(log.Fields{"image": package_update.Package.PackageVersion.PackageURL}).Error(err)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Image could not be parsed", "image": package_update.Package.PackageVersion.PackageURL})
+				log.WithFields(log.Fields{"image": package_update.RegistryPackage.PackageVersion.PackageURL}).Error(err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Image could not be parsed", "image": package_update.RegistryPackage.PackageVersion.PackageURL})
 			}
 
 			// Spawns an async process to update the services.

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gin-gonic/gin/binding"
 )
 
-const Version = "0.1.0"
+const Version = "0.1.1"
 
 var cnf = config.LoadConfig()
 


### PR DESCRIPTION
Configure the struct to parse webhook as a `registry_package` model in order to avoid authentication rejections due to body mismatches 